### PR TITLE
Makefile: use regular SYSD_DIR for LuneOS as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,7 @@ APPS_DIRECTORY_DIR := $(PREFIX)/share/desktop-directories
 APPS_MENU_DIR := /etc/xdg/menus/applications-merged
 METAINFO_DIR := $(PREFIX)/share/metainfo
 ICONS_DIR := $(PREFIX)/share/icons
-SYSD_DIR := $(PREFIX)/lib/systemd/system
-SYSD_DIR_LUNEOS := /lib/systemd/system
+SYSD_DIR ?= $(PREFIX)/lib/systemd/system
 DBUS_DIR := $(PREFIX)/share/dbus-1
 POLKIT_DIR := $(PREFIX)/share/polkit-1
 APPARMOR_DIR := /etc/apparmor.d
@@ -31,7 +30,6 @@ INSTALL_APPS_MENU_DIR := $(DESTDIR)$(APPS_MENU_DIR)
 INSTALL_METAINFO_DIR := $(DESTDIR)$(METAINFO_DIR)
 INSTALL_ICONS_DIR := $(DESTDIR)$(ICONS_DIR)
 INSTALL_SYSD_DIR := $(DESTDIR)$(SYSD_DIR)
-INSTALL_SYSD_DIR_LUNEOS := $(DESTDIR)$(SYSD_DIR_LUNEOS)
 INSTALL_DBUS_DIR := $(DESTDIR)$(DBUS_DIR)
 INSTALL_POLKIT_DIR := $(DESTDIR)$(POLKIT_DIR)
 INSTALL_APPARMOR_DIR := $(DESTDIR)$(APPARMOR_DIR)
@@ -84,9 +82,9 @@ install_luneos:
 		cp -vrf dbus/$(APP_ID).service $(INSTALL_DBUS_DIR)/system-services/$(APP_ID).service; \
 	fi
 	if [ $(USE_SYSTEMD) = 1 ]; then \
-		install -d $(INSTALL_SYSD_DIR_LUNEOS); \
-		cp -vrf systemd/waydroid-container-luneos.service $(INSTALL_SYSD_DIR_LUNEOS)/waydroid-container.service; \
-		cp -vrf systemd/waydroid-init-luneos.service $(INSTALL_SYSD_DIR_LUNEOS)/waydroid-init.service; \
+		install -d $(INSTALL_SYSD_DIR); \
+		cp -vrf systemd/waydroid-container-luneos.service $(INSTALL_SYSD_DIR)/waydroid-container.service; \
+		cp -vrf systemd/waydroid-init-luneos.service $(INSTALL_SYSD_DIR)/waydroid-init.service; \
 	fi
 	if [ $(USE_NFTABLES) = 1 ]; then \
 		sed '/LXC_USE_NFT=/ s/false/true/' -i $(INSTALL_WAYDROID_DIR)/data/scripts/waydroid-net.sh; \


### PR DESCRIPTION
* and allow it to be set from outside

* fixes: ERROR: waydroid-1.4.2+git-r0 do_package: QA Issue: waydroid: Files/directories were installed but not shipped in any package:
  /lib
  /lib/systemd
  /lib/systemd/system
  /lib/systemd/system/waydroid-container.service
  /lib/systemd/system/waydroid-init.service
Please set FILES such that these items are packaged. Alternatively if they are unneeded, avoid installing them or delete them within do_install. waydroid: 5 installed and not shipped files. [installed-vs-shipped]

when e.g. usrmerge is used and systemd_unitdir="/usr/lib/systemd" and waydroid didn't respect that and installed the files in /lib/systemd instead.

Allow to set SYSD_DIR from outside with EXTRA_OEMAKE to use: systemd_system_unitdir="/usr/lib/systemd/system"
like the most of other recipes do.